### PR TITLE
fix: define _MAC_AVAILABLE in screen_capture_tools.py

### DIFF
--- a/word_document_server/tools/screen_capture_tools.py
+++ b/word_document_server/tools/screen_capture_tools.py
@@ -4,6 +4,8 @@ import json
 import os
 import sys
 
+_MAC_AVAILABLE = sys.platform == 'darwin'
+
 
 def _capture_window_to_png(hwnd: int) -> bytes:
     """Capture a window using PrintWindow and return PNG bytes.


### PR DESCRIPTION
## Summary

Fixes #8.

`word_screen_capture` references `_MAC_AVAILABLE` at line 75 but the module never defines it, causing `NameError` on every call (both Windows and macOS).

The other tool modules (`live_tools.py`, `live_read_tools.py`, `live_layout_tools.py`) all define `_MAC_AVAILABLE` at module top with the same pattern — this file was simply missing it.

## Change

One line added after the `import sys`:

```python
_MAC_AVAILABLE = sys.platform == 'darwin'
```

## Test plan

- [x] Verified `word_screen_capture` works on Windows 11 after patch
- [ ] Not tested on macOS — but the existing `if _MAC_AVAILABLE:` branch routes to `mac_screen_capture`, which was presumably tested when it was written --> CANNOT TEST MYSELF SINCE I DON'T OWN A MAC