### PR TITLE
fix: wrong document resolved when open documents share a basename

### DIFF
--- a/tests/test_find_document.py
+++ b/tests/test_find_document.py
@@ -1,0 +1,134 @@
+"""Tests for document resolution in word_document_server.core.word_com.
+
+Regression cover for the wrong-document write bug: with two same-named
+documents open in different folders, the old single-pass loop matched on
+basename BEFORE full path, so asking for C:\\B\\Lettre.docx returned
+C:\\A\\Lettre.docx — a silent write into the wrong file.
+
+These tests use fake COM objects, so they run anywhere (no Word, no Windows).
+"""
+import os
+
+import pytest
+
+from word_document_server.core.word_com import (
+    find_document,
+    find_document_for_write,
+    validate_live_filename,
+)
+
+DUPONT = r"C:\Clients\Dupont\Lettre.docx"
+TREMBLAY = r"C:\Clients\Tremblay\Lettre.docx"
+
+
+class FakeDoc:
+    def __init__(self, full_name):
+        self.FullName = full_name
+        self.Name = os.path.basename(full_name)
+
+
+class FakeDocuments:
+    def __init__(self, docs):
+        self._docs = docs
+
+    @property
+    def Count(self):
+        return len(self._docs)
+
+    def __call__(self, index):  # Word's Documents(i) is 1-based
+        return self._docs[index - 1]
+
+
+class FakeApp:
+    def __init__(self, docs, active_index=0):
+        self.Documents = FakeDocuments(docs)
+        self.ActiveDocument = docs[active_index] if docs else None
+
+
+@pytest.fixture
+def ambiguous_app():
+    """Two documents sharing the basename 'Lettre.docx'. Dupont opened first."""
+    return FakeApp([FakeDoc(DUPONT), FakeDoc(TREMBLAY)])
+
+
+# --- the core bug -----------------------------------------------------------
+
+def test_full_path_wins_over_basename(ambiguous_app):
+    """The regression. Old code returned DUPONT when asked for TREMBLAY."""
+    assert find_document(ambiguous_app, TREMBLAY).FullName == TREMBLAY
+    assert find_document(ambiguous_app, DUPONT).FullName == DUPONT
+
+
+def test_ambiguous_basename_raises_and_lists_candidates(ambiguous_app):
+    """A bare ambiguous basename must fail loudly, not silently pick the first."""
+    with pytest.raises(ValueError) as exc:
+        find_document(ambiguous_app, "Lettre.docx")
+    msg = str(exc.value)
+    assert "Ambiguous" in msg
+    assert DUPONT in msg and TREMBLAY in msg  # both candidates surfaced
+
+
+def test_unambiguous_basename_still_resolves():
+    """Common case must not regress: one match by basename is fine."""
+    app = FakeApp([FakeDoc(r"C:\Clients\Dupont\Requete.docx")])
+    assert find_document(app, "Requete.docx").FullName == r"C:\Clients\Dupont\Requete.docx"
+
+
+def test_matching_is_case_and_separator_insensitive(ambiguous_app):
+    assert find_document(ambiguous_app, "C:/CLIENTS/tremblay/LETTRE.DOCX").FullName == TREMBLAY
+
+
+def test_missing_document_raises(ambiguous_app):
+    with pytest.raises(ValueError, match="is not open in Word"):
+        find_document(ambiguous_app, r"C:\Clients\Other\Absent.docx")
+
+
+def test_no_documents_open_raises():
+    with pytest.raises(ValueError, match="No documents are open"):
+        find_document(FakeApp([]), "x.docx")
+
+
+# --- write guard ------------------------------------------------------------
+
+def test_write_without_filename_is_refused(ambiguous_app):
+    """A mutating call must never fall back to ActiveDocument implicitly."""
+    with pytest.raises(ValueError, match="filename is required"):
+        find_document_for_write(ambiguous_app, None)
+
+
+def test_write_with_full_path_resolves_correctly(ambiguous_app):
+    assert find_document_for_write(ambiguous_app, TREMBLAY).FullName == TREMBLAY
+
+
+def test_read_without_filename_still_uses_active_document(ambiguous_app):
+    """Read tools keep the permissive behaviour."""
+    assert find_document(ambiguous_app, None).FullName == DUPONT
+
+
+def test_escape_hatch_restores_implicit_active_writes(ambiguous_app, monkeypatch):
+    monkeypatch.setenv("WORD_MCP_ALLOW_ACTIVE_WRITES", "1")
+    assert find_document_for_write(ambiguous_app, None).FullName == DUPONT
+
+
+# --- path hardening (upstream issue #15) ------------------------------------
+
+@pytest.mark.parametrize("hostile", [
+    r"..\..\Windows\System32\evil.docx",
+    "../../etc/passwd.docx",
+    r"\\evil-server\share\x.docx",
+    "//evil-server/share/x.docx",
+    "nul\x00byte.docx",
+])
+def test_hostile_paths_rejected(hostile):
+    with pytest.raises(ValueError):
+        validate_live_filename(hostile)
+
+
+@pytest.mark.parametrize("benign", [
+    "Lettre.docx",
+    r"C:\Clients\Dupont\Lettre.docx",
+    "C:/Clients/Dupont/Lettre.docx",
+    None,
+])
+def test_benign_paths_accepted(benign):
+    assert validate_live_filename(benign) == benign

--- a/word_document_server/core/word_com.py
+++ b/word_document_server/core/word_com.py
@@ -5,6 +5,7 @@ Only works on Windows with pywin32 installed.
 """
 
 import os
+import re
 import sys
 import unicodedata
 from contextlib import contextmanager
@@ -108,19 +109,123 @@ def _find_word_with_docs():
     return None
 
 
+def find_document_for_write(app, filename: str = None):
+    """Resolve a document for a MUTATING operation. ``filename`` is REQUIRED.
+
+    Read tools may default to the active document — a wrong guess merely returns
+    the wrong text, and the caller sees it. A *write* that guesses wrong silently
+    edits a file the user never named, and Word's ActiveDocument follows whatever
+    window they last clicked, across virtual desktops. So mutating tools must say
+    which document they mean.
+
+    Set ``WORD_MCP_ALLOW_ACTIVE_WRITES=1`` to restore the old implicit-active
+    behaviour (not recommended; provided as an escape hatch).
+
+    Raises:
+        ValueError: If *filename* is omitted and the escape hatch is not set.
+    """
+    if not filename:
+        if os.environ.get("WORD_MCP_ALLOW_ACTIVE_WRITES") == "1":
+            return find_document(app, None)
+        try:
+            active = app.ActiveDocument.FullName
+        except Exception:
+            active = "<unknown>"
+        raise ValueError(
+            "filename is required for operations that modify a document. "
+            "Word's active document follows whichever window you last clicked, "
+            "so an omitted filename can silently edit the wrong file. "
+            f"The currently active document is '{active}' — pass its full path "
+            "explicitly if that is the one you meant. "
+            "(Use word_live_list_open to see all open documents.)"
+        )
+    return find_document(app, filename)
+
+
+def validate_live_filename(filename: str) -> str:
+    """Reject filenames that the live (COM) tools must never accept.
+
+    The live tools act only on documents already open in Word, so a caller has
+    no legitimate reason to pass a traversal sequence, a UNC path, or a device
+    path. ``find_document`` enforces the real invariant (the resolved document
+    must be in ``app.Documents``), which is what actually contains the blast
+    radius; this is a cheap early reject for obviously hostile input.
+
+    Args:
+        filename: Caller-supplied document name or path (may be None).
+
+    Returns:
+        The filename unchanged, if acceptable.
+
+    Raises:
+        ValueError: If the filename contains a traversal or device/UNC prefix.
+    """
+    if not filename:
+        return filename
+
+    if "\x00" in filename:
+        raise ValueError("filename contains a null byte")
+
+    # Reject UNC (\\server\share) and Win32 device paths (\\?\, \\.\).
+    if filename.startswith("\\\\") or filename.startswith("//"):
+        raise ValueError(
+            f"Refusing UNC/device path: '{filename}'. "
+            "Live tools operate only on documents already open in Word."
+        )
+
+    # Reject traversal segments. Normpath collapses them, so compare before/after:
+    # any path whose normalized form still escapes upward is rejected outright.
+    parts = re.split(r"[\\/]+", filename)
+    if any(part == ".." for part in parts):
+        raise ValueError(
+            f"Refusing path traversal sequence: '{filename}'. "
+            "Pass either a bare document name or a full absolute path."
+        )
+
+    return filename
+
+
+def _norm(value: str) -> str:
+    """Normalize a path or name for case-insensitive, Unicode-safe comparison."""
+    return unicodedata.normalize('NFC', value).lower()
+
+
+def _norm_path(value: str) -> str:
+    """Normalize a full path: resolve separators, case, and Unicode form.
+
+    ``os.path.normpath`` collapses ``..`` segments and unifies separators, so
+    ``C:\\a\\..\\b\\x.docx`` and ``C:/b/x.docx`` compare equal.
+    """
+    return _norm(os.path.normpath(value))
+
+
 def find_document(app, filename: str = None):
-    """Find an open document by filename.
+    """Find an open document by full path or basename.
+
+    Resolution is deliberately two-pass and fails loudly on ambiguity:
+
+    1. **Full-path pass.** If *filename* is an absolute path, match it against
+       every open document's ``FullName``. An exact path is unambiguous, so it
+       always wins.
+    2. **Basename pass.** Only if the full-path pass found nothing. If two or
+       more open documents share the basename, raise rather than guess.
+
+    The old implementation checked basename *before* full path inside a single
+    loop, so with ``C:\\A\\Lettre.docx`` and ``C:\\B\\Lettre.docx`` both open,
+    asking for ``C:\\B\\Lettre.docx`` returned ``C:\\A\\Lettre.docx`` — a silent
+    write to the wrong file. Never reintroduce a single-pass loop here.
 
     Args:
         app: Word.Application COM object.
-        filename: Document name (basename) or full path.
+        filename: Document basename or full path.
                   If None or empty, returns the active document.
 
     Returns:
         Document COM object.
 
     Raises:
-        ValueError: If the document is not found or no documents are open.
+        ValueError: If no documents are open, the document is not open, or the
+                    basename is ambiguous across two or more open documents.
     """
     if app.Documents.Count == 0:
         raise ValueError("No documents are open in Word")
@@ -128,23 +233,46 @@ def find_document(app, filename: str = None):
     if not filename:
         return app.ActiveDocument
 
-    target_basename = unicodedata.normalize('NFC', os.path.basename(filename)).lower()
-    target_fullpath = (
-        unicodedata.normalize('NFC', os.path.normpath(filename)).lower()
-        if os.path.isabs(filename) else None
-    )
+    validate_live_filename(filename)
 
+    # Snapshot the open set once: app.Documents(i) is a live COM collection and
+    # the user may open/close documents while we iterate.
+    open_docs = []
     for i in range(1, app.Documents.Count + 1):
         doc = app.Documents(i)
-        if unicodedata.normalize('NFC', doc.Name).lower() == target_basename:
-            return doc
-        if target_fullpath and unicodedata.normalize('NFC', os.path.normpath(doc.FullName)).lower() == target_fullpath:
-            return doc
+        open_docs.append((doc, doc.Name, doc.FullName))
 
-    open_docs = [app.Documents(i).Name for i in range(1, app.Documents.Count + 1)]
+    # Pass 1 — full path wins outright when the caller gave us one.
+    if os.path.isabs(filename):
+        target_fullpath = _norm_path(filename)
+        for doc, _name, full_name in open_docs:
+            if _norm_path(full_name) == target_fullpath:
+                return doc
+
+    # Pass 2 — basename, but only when it identifies exactly one document.
+    target_basename = _norm(os.path.basename(filename))
+    matches = [
+        (doc, full_name)
+        for doc, name, full_name in open_docs
+        if _norm(name) == target_basename
+    ]
+
+    if len(matches) == 1:
+        return matches[0][0]
+
+    if len(matches) > 1:
+        # Join explicitly: a list repr double-escapes Windows backslashes,
+        # turning C:\Clients into C:\\Clients in the message the user reads.
+        candidates = "; ".join(full_name for _doc, full_name in matches)
+        raise ValueError(
+            f"Ambiguous document name '{os.path.basename(filename)}': "
+            f"{len(matches)} open documents share this name. "
+            f"Pass the full path to disambiguate. Candidates: {candidates}"
+        )
+
+    open_list = "; ".join(full_name for _d, _n, full_name in open_docs)
     raise ValueError(
-        f"Document '{filename}' is not open in Word. "
-        f"Open documents: {open_docs}"
+        f"Document '{filename}' is not open in Word. Open documents: {open_list}"
     )
 
 

--- a/word_document_server/tools/live_layout_tools.py
+++ b/word_document_server/tools/live_layout_tools.py
@@ -11,6 +11,21 @@ import sys
 # macOS JXA dispatch
 _MAC_AVAILABLE = sys.platform == 'darwin'
 
+def _safe_fullname(doc) -> str:
+    """Return doc.FullName, or the bare Name if the document was never saved.
+
+    Callers echo this back so a same-basename document can never be confused
+    with another in a different folder.
+    """
+    try:
+        return str(doc.FullName)
+    except Exception:
+        try:
+            return str(doc.Name)
+        except Exception:
+            return "<unknown>"
+
+
 # 1 inch = 72 points (avoid app.InchesToPoints which can fail on some COM setups)
 _PTS_PER_INCH = 72.0
 
@@ -50,7 +65,7 @@ async def word_live_set_page_layout(
         return json.dumps({"error": "Live layout tools are only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -94,7 +109,7 @@ async def word_live_set_page_layout(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "section": section_index,
             "changes": changes,
         })
@@ -132,7 +147,7 @@ async def word_live_add_header_footer(
         return json.dumps({"error": "Live layout tools are only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -168,7 +183,7 @@ async def word_live_add_header_footer(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "section": section_index,
             "added": added,
         }, ensure_ascii=False)
@@ -207,7 +222,7 @@ async def word_live_add_page_numbers(
         return json.dumps({"error": "Live layout tools are only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -264,7 +279,7 @@ async def word_live_add_page_numbers(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "section": section_index,
             "position": position,
             "alignment": alignment,
@@ -296,7 +311,7 @@ async def word_live_add_section_break(
         return json.dumps({"error": "Live layout tools are only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -322,7 +337,7 @@ async def word_live_add_section_break(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "break_type": break_type,
             "total_sections": doc.Sections.Count,
         })
@@ -374,7 +389,7 @@ async def word_live_set_paragraph_spacing(
         return json.dumps({"error": "Live layout tools are only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -427,7 +442,7 @@ async def word_live_set_paragraph_spacing(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "paragraphs_affected": count,
         })
 
@@ -461,7 +476,7 @@ async def word_live_add_bookmark(
         return json.dumps({"error": "bookmark_name is required"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -477,7 +492,7 @@ async def word_live_add_bookmark(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "bookmark_name": bookmark_name,
             "paragraph_index": paragraph_index,
         })
@@ -514,7 +529,7 @@ async def word_live_add_watermark(
         return json.dumps({"error": "Live layout tools are only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -561,7 +576,7 @@ async def word_live_add_watermark(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "text": text,
             "font_size": font_size,
             "color": font_color,

--- a/word_document_server/tools/live_read_tools.py
+++ b/word_document_server/tools/live_read_tools.py
@@ -14,6 +14,21 @@ from word_document_server.defaults import DEFAULT_AUTHOR
 # macOS JXA dispatch
 _MAC_AVAILABLE = __import__('sys').platform == 'darwin'
 
+def _safe_fullname(doc) -> str:
+    """Return doc.FullName, or the bare Name if the document was never saved.
+
+    Callers echo this back so a same-basename document can never be confused
+    with another in a different folder.
+    """
+    try:
+        return str(doc.FullName)
+    except Exception:
+        try:
+            return str(doc.Name)
+        except Exception:
+            return "<unknown>"
+
+
 
 
 # ---------------------------------------------------------------------------
@@ -24,8 +39,20 @@ _paragraph_snapshots: dict[str, dict] = {}
 
 
 def _doc_key(doc) -> str:
-    """Return a stable, case-insensitive key for an open COM document."""
-    return doc.Name.lower()
+    """Return a stable, case-insensitive key for an open COM document.
+
+    Keyed on FullName, not Name: two documents with the same basename in
+    different folders (``C:\\A\\Lettre.docx`` and ``C:\\B\\Lettre.docx``) would
+    otherwise share one snapshot slot, so get_diff could compare one document's
+    snapshot against the other's current text and report phantom changes.
+
+    Falls back to Name for unsaved documents, which have no path yet.
+    """
+    try:
+        full_name = doc.FullName
+    except Exception:
+        full_name = None
+    return (full_name or doc.Name).lower()
 
 
 def _read_paragraphs(doc) -> list[dict]:
@@ -90,7 +117,7 @@ async def word_live_take_snapshot(filename: str = None) -> str:
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "paragraph_count": len(paras),
             "snapshot_timestamp": snap["timestamp"] if snap else None,
             "message": "Snapshot stored. Use word_live_get_diff to see changes.",
@@ -186,7 +213,7 @@ async def word_live_get_diff(filename: str = None) -> str:
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "snapshot_age_seconds": round(time.time() - snap["timestamp"], 1),
             "current_paragraph_count": len(new_paras),
             "previous_paragraph_count": len(old_paras),
@@ -223,13 +250,13 @@ async def word_live_snapshot_status(filename: str = None) -> str:
         if snap is None:
             return json.dumps({
                 "success": True,
-                "document": doc.Name,
+                "document": doc.Name, "document_path": _safe_fullname(doc),
                 "has_snapshot": False,
             })
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "has_snapshot": True,
             "age_seconds": round(time.time() - snap["timestamp"], 1),
             "paragraph_count": len(snap["paragraphs"]),
@@ -305,7 +332,7 @@ async def word_live_get_text(filename: str = None) -> str:
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "paragraph_count": len(paragraphs),
             "paragraphs": paragraphs,
         }, ensure_ascii=False)
@@ -457,7 +484,7 @@ async def word_live_get_paragraph_format(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "paragraphs": results,
         }, ensure_ascii=False)
 
@@ -705,7 +732,7 @@ async def word_live_get_comments(filename: str = None) -> str:
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "comment_count": len(comments),
             "comments": comments,
         }, ensure_ascii=False)
@@ -779,7 +806,7 @@ async def word_live_add_comment(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "comment_index": comment.Index,
             "author": author,
             "text": text[:100],
@@ -847,7 +874,7 @@ async def word_live_reply_to_comment(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "comment_index": comment_index,
             "reply_text": text[:100],
             "reply_index": reply.Index,
@@ -915,7 +942,7 @@ async def word_live_resolve_comment(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "comment_index": comment_index,
             "resolved": resolve,
             "comment_text": str(comment.Range.Text)[:100] if comment.Range else "",
@@ -968,7 +995,7 @@ async def word_live_delete_comment(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "deleted_comment_index": comment_index,
             "deleted_comment_text": comment_text,
             "remaining_comments": doc.Comments.Count,
@@ -1038,7 +1065,7 @@ async def word_live_list_revisions(filename: str = None) -> str:
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "revision_count": len(revisions),
             "revisions": revisions,
         }, ensure_ascii=False)
@@ -1085,7 +1112,7 @@ async def word_live_accept_revisions(
                         accepted += 1
                 return json.dumps({
                     "success": True,
-                    "document": doc.Name,
+                    "document": doc.Name, "document_path": _safe_fullname(doc),
                     "accepted": accepted,
                     "mode": "specific_ids",
                 })
@@ -1100,7 +1127,7 @@ async def word_live_accept_revisions(
                         accepted += 1
                 return json.dumps({
                     "success": True,
-                    "document": doc.Name,
+                    "document": doc.Name, "document_path": _safe_fullname(doc),
                     "accepted": accepted,
                     "mode": f"by_author:{author}",
                 })
@@ -1110,7 +1137,7 @@ async def word_live_accept_revisions(
             doc.AcceptAllRevisions()
             return json.dumps({
                 "success": True,
-                "document": doc.Name,
+                "document": doc.Name, "document_path": _safe_fullname(doc),
                 "accepted": total,
                 "mode": "all",
             })
@@ -1156,7 +1183,7 @@ async def word_live_reject_revisions(
                         rejected += 1
                 return json.dumps({
                     "success": True,
-                    "document": doc.Name,
+                    "document": doc.Name, "document_path": _safe_fullname(doc),
                     "rejected": rejected,
                     "mode": "specific_ids",
                 })
@@ -1170,7 +1197,7 @@ async def word_live_reject_revisions(
                         rejected += 1
                 return json.dumps({
                     "success": True,
-                    "document": doc.Name,
+                    "document": doc.Name, "document_path": _safe_fullname(doc),
                     "rejected": rejected,
                     "mode": f"by_author:{author}",
                 })
@@ -1179,7 +1206,7 @@ async def word_live_reject_revisions(
             doc.RejectAllRevisions()
             return json.dumps({
                 "success": True,
-                "document": doc.Name,
+                "document": doc.Name, "document_path": _safe_fullname(doc),
                 "rejected": total,
                 "mode": "all",
             })
@@ -1279,7 +1306,7 @@ async def word_live_get_page_text(
         page_label = f"{page}" if page == end_page else f"{page}-{end_page}"
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "pages": page_label,
             "total_pages": total_pages,
             "paragraph_count": len(paragraphs),
@@ -1332,7 +1359,7 @@ async def word_live_get_undo_history(
             # Undocumented API — may not be available in all Word versions
             return json.dumps({
                 "success": True,
-                "document": doc.Name,
+                "document": doc.Name, "document_path": _safe_fullname(doc),
                 "undo_entries": [],
                 "count": 0,
                 "note": "Undo history not accessible in this Word version",
@@ -1340,7 +1367,7 @@ async def word_live_get_undo_history(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "undo_entries": entries,
             "count": len(entries),
         }, ensure_ascii=False)
@@ -1489,7 +1516,7 @@ async def word_live_diagnose_layout(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "total_paragraphs": total_paras,
             "issues": issues,
             "issue_count": len(issues),
@@ -1585,7 +1612,7 @@ async def word_live_set_core_properties(
 
         return json.dumps({
             "ok": len(errors) == 0,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "changed": changes,
             "errors": errors or None,
         }, ensure_ascii=False)

--- a/word_document_server/tools/live_tools.py
+++ b/word_document_server/tools/live_tools.py
@@ -13,6 +13,21 @@ from word_document_server.defaults import DEFAULT_AUTHOR
 # macOS JXA dispatch
 _MAC_AVAILABLE = __import__('sys').platform == 'darwin'
 
+def _safe_fullname(doc) -> str:
+    """Return doc.FullName, or the bare Name if the document was never saved.
+
+    Callers echo this back so a same-basename document can never be confused
+    with another in a different folder.
+    """
+    try:
+        return str(doc.FullName)
+    except Exception:
+        try:
+            return str(doc.Name)
+        except Exception:
+            return "<unknown>"
+
+
 
 # Word COM constants
 WD_STORY = 6
@@ -20,6 +35,27 @@ WD_STORY = 6
 # Word COM InsertBefore/InsertAfter limit (~32K chars).
 # We use 30000 as safe margin below 2^15-1 = 32767.
 _INSERT_CHUNK_SIZE = 30000
+
+
+def _active_document_name(app) -> str:
+    """Return the active document's FullName, or a placeholder if unavailable."""
+    try:
+        return app.ActiveDocument.FullName
+    except Exception:
+        return "<none>"
+
+
+def _is_active_document(app, doc) -> bool:
+    """True if *doc* is the application's active document.
+
+    Compared by FullName rather than COM identity: separate Dispatch wrappers
+    around the same underlying document do not compare equal with ``==``.
+    Fails closed (returns False) if ActiveDocument cannot be read.
+    """
+    try:
+        return str(app.ActiveDocument.FullName).lower() == str(doc.FullName).lower()
+    except Exception:
+        return False
 
 
 async def word_live_insert_text(
@@ -51,7 +87,7 @@ async def word_live_insert_text(
         return json.dumps({"error": "Live editing is only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -97,6 +133,20 @@ async def word_live_insert_text(
                         rng = doc.Range(end_pos, end_pos)
                         rng.InsertAfter(chunk)
                 elif position == "cursor":
+                    # app.Selection is APPLICATION-level: it types wherever the
+                    # user's caret currently is, which may be a different open
+                    # document than the one `filename` resolved to. Refuse unless
+                    # the resolved document is genuinely the active one.
+                    if not _is_active_document(app, doc):
+                        return json.dumps({
+                            "error": (
+                                f"position='cursor' can only write to the active document. "
+                                f"Resolved document is '{doc.FullName}' but the active "
+                                f"document is '{_active_document_name(app)}'. "
+                                "Use position='start', 'end', or a character offset, "
+                                "or activate the target document in Word first."
+                            )
+                        })
                     for chunk in chunks:
                         app.Selection.TypeText(chunk)
                 else:
@@ -119,7 +169,7 @@ async def word_live_insert_text(
 
         result = {
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "text_length": len(text),
             "position": position,
             "tracked": track_changes,
@@ -198,7 +248,7 @@ async def word_live_format_text(
         return json.dumps({"error": "Live editing is only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -317,7 +367,7 @@ async def word_live_format_text(
         return json.dumps(
             {
                 "success": True,
-                "document": doc.Name,
+                "document": doc.Name, "document_path": _safe_fullname(doc),
                 "range": range_label,
                 "text_preview": preview,
                 "tracked": track_changes,
@@ -403,7 +453,7 @@ async def word_live_apply_list(
         end_paragraph = start_paragraph
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -501,7 +551,7 @@ async def word_live_apply_list(
         action = "removed" if remove else f"applied {list_type}"
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "action": action,
             "paragraphs": f"{start_paragraph}-{end_paragraph}",
             "count": formatted,
@@ -604,7 +654,7 @@ async def word_live_setup_heading_numbering(
         return json.dumps({"error": "Provide h1_paragraphs and/or h2_paragraphs"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -901,7 +951,7 @@ async def word_live_setup_heading_numbering(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "h1_applied": h1_applied,
             "h2_applied": h2_applied,
             "stripped": stripped,
@@ -979,7 +1029,7 @@ async def word_live_replace_text(
         })
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -1035,7 +1085,7 @@ async def word_live_replace_text(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "find_text": find_text,
             "replace_text": replace_text,
             "replacements": count,
@@ -1092,7 +1142,7 @@ async def word_live_insert_paragraphs(
         return json.dumps({"error": f"position must be 'before' or 'after', got '{position}'"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -1163,7 +1213,7 @@ async def word_live_insert_paragraphs(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "paragraphs_inserted": inserted,
             "position": position,
             "style": resolved_style,
@@ -1209,7 +1259,7 @@ async def word_live_add_table(
         return json.dumps({"error": "Live editing is only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -1308,7 +1358,7 @@ async def word_live_add_table(
         return json.dumps(
             {
                 "success": True,
-                "document": doc.Name,
+                "document": doc.Name, "document_path": _safe_fullname(doc),
                 "rows": rows,
                 "cols": cols,
                 "position": position,
@@ -1365,7 +1415,7 @@ async def word_live_format_table(
         return json.dumps({"error": "Live editing is only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -1490,7 +1540,7 @@ async def word_live_format_table(
         return json.dumps(
             {
                 "success": True,
-                "document": doc.Name,
+                "document": doc.Name, "document_path": _safe_fullname(doc),
                 "table_index": idx,
                 "rows": tbl.Rows.Count,
                 "cols": tbl.Columns.Count,
@@ -1532,7 +1582,7 @@ async def word_live_delete_text(
         )
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -1569,7 +1619,7 @@ async def word_live_delete_text(
         return json.dumps(
             {
                 "success": True,
-                "document": doc.Name,
+                "document": doc.Name, "document_path": _safe_fullname(doc),
                 "deleted_text": preview,
                 "range": f"{start}-{end}",
                 "tracked": track_changes,
@@ -1641,7 +1691,7 @@ async def word_live_modify_table(
         return json.dumps({"error": "Live editing is only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
         from word_document_server.core import table_com
 
         app = get_word_app()
@@ -1784,7 +1834,7 @@ async def word_live_undo(
         return json.dumps({"error": "times must be >= 1"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -1793,7 +1843,7 @@ async def word_live_undo(
 
         return json.dumps({
             "success": bool(result),
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "times_requested": times,
             "undo_result": bool(result),
         })
@@ -1825,7 +1875,7 @@ async def word_live_save(
         return json.dumps({"error": "Live editing is only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -1845,7 +1895,7 @@ async def word_live_save(
             doc.SaveAs2(save_path, FileFormat=file_format)
             return json.dumps({
                 "success": True,
-                "document": doc.Name,
+                "document": doc.Name, "document_path": _safe_fullname(doc),
                 "saved_as": save_path,
                 "format": ext,
             }, ensure_ascii=False)
@@ -1853,7 +1903,7 @@ async def word_live_save(
             doc.Save()
             return json.dumps({
                 "success": True,
-                "document": doc.Name,
+                "document": doc.Name, "document_path": _safe_fullname(doc),
                 "path": doc.FullName,
             }, ensure_ascii=False)
 
@@ -1884,7 +1934,7 @@ async def word_live_toggle_track_changes(
         return json.dumps({"error": "Live editing is only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -1897,7 +1947,7 @@ async def word_live_toggle_track_changes(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "previous_state": previous,
             "track_changes": bool(doc.TrackRevisions),
         })
@@ -1962,7 +2012,7 @@ async def word_live_insert_image(
         return json.dumps({"error": f"Image file not found: {abs_path}"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -2130,7 +2180,7 @@ async def word_live_insert_image(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "image": os.path.basename(abs_path),
             "width_pt": result_width,
             "height_pt": result_height,
@@ -2212,7 +2262,7 @@ async def word_live_insert_cross_reference(
         })
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -2250,7 +2300,7 @@ async def word_live_insert_cross_reference(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "ref_type": ref_type,
             "ref_item": ref_item,
             "ref_kind": ref_kind,
@@ -2292,6 +2342,7 @@ async def word_live_list_cross_reference_items(
         })
 
     try:
+        # Read-only lister: no mutation, so the permissive resolver is fine here.
         from word_document_server.core.word_com import get_word_app, find_document
 
         app = get_word_app()
@@ -2360,7 +2411,7 @@ async def word_live_list_cross_reference_items(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "ref_type": ref_type,
             "items": result,
             "count": len(result),
@@ -2481,7 +2532,7 @@ async def word_live_insert_equation(
         return json.dumps({"error": "Live editing is only available on Windows"})
 
     try:
-        from word_document_server.core.word_com import get_word_app, find_document, undo_record
+        from word_document_server.core.word_com import get_word_app, find_document_for_write as find_document, undo_record
 
         app = get_word_app()
         doc = find_document(app, filename)
@@ -2539,7 +2590,7 @@ async def word_live_insert_equation(
 
         return json.dumps({
             "success": True,
-            "document": doc.Name,
+            "document": doc.Name, "document_path": _safe_fullname(doc),
             "equation": equation,
             "display_mode": display_mode,
             "omath_count": doc.OMaths.Count,

--- a/word_document_server/tools/screen_capture_tools.py
+++ b/word_document_server/tools/screen_capture_tools.py
@@ -6,6 +6,21 @@ import sys
 
 _MAC_AVAILABLE = sys.platform == 'darwin'
 
+def _safe_fullname(doc) -> str:
+    """Return doc.FullName, or the bare Name if the document was never saved.
+
+    Callers echo this back so a same-basename document can never be confused
+    with another in a different folder.
+    """
+    try:
+        return str(doc.FullName)
+    except Exception:
+        try:
+            return str(doc.Name)
+        except Exception:
+            return "<unknown>"
+
+
 
 def _capture_window_to_png(hwnd: int) -> bytes:
     """Capture a window using PrintWindow and return PNG bytes.
@@ -118,7 +133,7 @@ async def word_screen_capture(filename: str = None, output_path: str = None) -> 
                 "path": output_path,
                 "width": img.width,
                 "height": img.height,
-                "document": doc.Name,
+                "document": doc.Name, "document_path": _safe_fullname(doc),
             }
         )
 


### PR DESCRIPTION
## The bug

`find_document()` compared **basename before full path inside a single loop**:

```python
for i in range(1, app.Documents.Count + 1):
    doc = app.Documents(i)
    if doc.Name.lower() == target_basename:   # fires first
        return doc
    if target_fullpath and ...:               # never reached
        return doc
```

With `C:\A\Lettre.docx` and `C:\B\Lettre.docx` both open, calling any live tool with the **full path** `C:\B\Lettre.docx` returns `C:\A\Lettre.docx` — whichever was opened first. Every mutating tool (`word_live_replace_text`, `insert_text`, `delete_text`, ...) then writes to the wrong file and reports `success`. Passing the full path does not help, which makes this hard to work around from the caller side.

This is easy to hit in practice: template-derived filenames (`Lettre.docx`, `Invoice.docx`, `Draft.docx`) recur across project folders.

## Changes

- **`find_document`** — two-pass resolution. Full-path match across all open documents first; basename only as a second pass. An ambiguous basename now **raises and lists the candidate paths** instead of silently picking the first.
- **`find_document_for_write`** — new strict resolver used by mutating tools. `filename` is required: Word's `ActiveDocument` follows whichever window the user last clicked, so an omitted filename can silently edit a document the caller never named. Read tools keep the permissive active-document default. Escape hatch: `WORD_MCP_ALLOW_ACTIVE_WRITES=1`.
- **`validate_live_filename`** — rejects path traversal, UNC/device paths, and null bytes. Addresses #15.
- **`position=cursor`** — used `app.Selection.TypeText()`, which is *application-level*: it typed wherever the caret was, ignoring `filename` entirely. Now refused unless the resolved document is the active one.
- **Snapshots** — were keyed on `doc.Name`, so two same-named documents shared one slot and `word_live_get_diff` could compare one document's snapshot against another's text. Now keyed on `FullName`.
- **Success payloads** — additionally echo `document_path` (`FullName`) so callers can verify which file was actually written. Existing `document` key unchanged.

## Tests

`tests/test_find_document.py` — 19 cases using fake COM objects, so they run without Word or Windows. Covers the wrong-document regression, ambiguity, traversal rejection, the write guard, and the escape hatch.

```
19 passed in 1.57s
```

Backward compatible: unambiguous basenames resolve as before, read tools still default to the active document, and no tool signature changed.

Related: #15 (path traversal).