### PR TITLE
fix: stop drawing diagonal borders through every table cell

### DIFF
--- a/word_document_server/tools/live_tools.py
+++ b/word_document_server/tools/live_tools.py
@@ -1390,7 +1390,11 @@ async def word_live_format_table(
             "thick": 6,    # wdLineStyleThickThinSmallGap (thick)
         }
 
-        BORDER_IDS = [-1, -2, -3, -4, -5, -6, -7, -8]  # top, left, bottom, right, horiz, vert, etc.
+        # wdBorderTop/Left/Bottom/Right + wdBorderHorizontal/Vertical (inside gridlines).
+        BORDER_IDS = [-1, -2, -3, -4, -5, -6]
+        # wdBorderDiagonalDown/Up. Drawing these would put an X through every cell,
+        # so they are only ever cleared, never styled.
+        DIAGONAL_IDS = [-7, -8]
 
         with undo_record(app, "MCP: Format Table"):
             # --- Borders ---
@@ -1401,6 +1405,11 @@ async def word_live_format_table(
                 for bid in BORDER_IDS:
                     try:
                         tbl.Borders(bid).LineStyle = style_val
+                    except Exception:
+                        pass
+                for bid in DIAGONAL_IDS:
+                    try:
+                        tbl.Borders(bid).LineStyle = 0  # wdLineStyleNone
                     except Exception:
                         pass
                 actions.append(f"borders={border_style}")


### PR DESCRIPTION
## Problem

`word_live_format_table` applies the requested border style to `WdBorderType` ids `-1` through `-8`:

```python
BORDER_IDS = [-1, -2, -3, -4, -5, -6, -7, -8]  # top, left, bottom, right, horiz, vert, etc.
```

That trailing "etc." is the bug. Ids `-7` and `-8` are `wdBorderDiagonalDown` and `wdBorderDiagonalUp`. So a call as ordinary as `border_style="single"` draws **both diagonals inside every cell**, putting a visible X through the whole table.

The only way to get rid of the X today is `border_style="none"`, which happens to clear the diagonals too — at the cost of every real border.

## Fix

Restrict the styled ids to the four edges plus the two inside gridlines, and **always clear** the two diagonal ids. Clearing them rather than merely skipping them also repairs tables that an earlier version of this tool already polluted.

## Verification

Driven against Word via COM, reading back `LineStyle` on every border id:

| Border id | Old loop | New loop |
|---|---|---|
| `-1`..`-6` (edges + gridlines) | `1` | `1` |
| `-7` / `-8` (diagonals) | `1` — X drawn | `0` — clean |

Confirmed visually, and confirmed that a table pre-populated with diagonals comes out clean after a `border_style="single"` call.

The neighbouring border loop in `word_live_insert_image` is unaffected — it already correctly uses only `[-1, -2, -3, -4]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)